### PR TITLE
Resizing the window doesn't resize the messages

### DIFF
--- a/src/client-scripts/miaou.md.js
+++ b/src/client-scripts/miaou.md.js
@@ -207,6 +207,11 @@ var miaou = miaou || {};
 		resize();
 		$content.find('img').load(resize);
 	}
+	
+	// When the window is resized, all the messages have to be resized too.
+	$(window).on('resize', function() {
+		resize($('#messages'), true);
+	});
 
 	// inserts or updates a message in the main #messages div
 	md.addMessage = function(message){


### PR DESCRIPTION
When adding a message, they're resized to be correctly displayed. However, when the window is resized down, a message is resized to fit correctly. But when the window is resized back up, the messages aren't resized.

I'm not sure this is the best place to add this `$(window).resize()`, but I can't see anywhere else.
