### PR TITLE
CSS => fix margin div.radios (broken buttons on 1280x768 screen device)

### DIFF
--- a/src/scss/main.scss
+++ b/src/scss/main.scss
@@ -859,7 +859,7 @@ button.small {
 
 div.radios {
 	text-align: center;
-	margin: 4px;
+	margin: 3px;
 	span.label {
 		font-size: 90%;
 		margin-right: 4px;


### PR DESCRIPTION
CSS => fix margin div.radios (break ping buttons on 1280x768 screen device (Firefox))
