### PR TITLE
overflow hidden added.

### DIFF
--- a/static/intro2.scss
+++ b/static/intro2.scss
@@ -108,6 +108,7 @@ kbd {
 	}
 }
 #services {
+	overflow: hidden;
 	padding:20px;
 	white-space: nowrap;
 	ul {


### PR DESCRIPTION
This stops users from scrolling to the right when middle mouse clicking and should also fix the problem on mobile devices as well.
