### PR TITLE
Allow spell check on mobile.

### DIFF
--- a/views/chat.mob.jade
+++ b/views/chat.mob.jade
@@ -39,7 +39,7 @@ html
 		div#message-scroller
 			div#messages
 		div#input-panel
-			textarea#input(autocomplete="off")
+			textarea#input
 			button.small#send Send
 			
 		script.


### PR DESCRIPTION
Although autocomplete might be an issue on desktop (I believe this is why we added this attribute?), on mobile it's actually a good thing to have.

Removing the attribute fixes that.
