### PR TITLE
Stackoverflow presentation fix

### DIFF
--- a/plugins/stackoverflow/plugin.js
+++ b/plugins/stackoverflow/plugin.js
@@ -4,7 +4,7 @@ var Promise = require("bluebird"),
 	config,
 	request = require('request');
 	
-exports.name = "StackOverflow";
+exports.name = "Stack Overflow";
 
 // returns a promise
 // updates and provides in resolution the pluginPlayerInfos if successful, else throws an error 
@@ -53,7 +53,7 @@ function describeSOProfileCreation(user){
 	return [
 		"to validate you're the owner of this SO account, please put the following link in your SO profile :",
 		"<code>["+user.name+" @ Miaou]("+config.server+"/user/"+user.id+")</code>",
-		"As StackOverflow doesn't immediately update the public profile, you might have to wait 2 minutes before hitting the <i>Save</i> button below.",
+		"As Stack Overflow doesn't immediately update the public profile, you might have to wait 2 minutes before hitting the <i>Save</i> button below.",
 		"You'll be able to remove the link once the profile is checked. It would be nice to keep it, though.",
 	].join('<br>');
 }
@@ -62,7 +62,7 @@ exports.externalProfile = {
 	creation: {
 		describe: describeSOProfileCreation,
 		fields: [
-			{ name:'so_num', label:'StackOverflow User ID', type:'Number' }
+			{ name:'so_num', label:'Stack Overflow User ID', type:'Number' }
 		],
 		create: createSOProfile
 	}, render: renderSOProfile

--- a/views/help.jade
+++ b/views/help.jade
@@ -214,7 +214,7 @@ html
 				h3 Technical Stack
 				p Miaou is mostly coded in JavaScript. Stuff includes node.js, PostgreSQL, OAuth2, socket.io, WebRTC, express, Bluebird, Jade, Passport.js, jQuery, sass/scss, Redis, hu.js, and nginx.
 				h3 Contribute
-				p Miaou has a small source code simply structured and should remain so. You may easily dive into the code which is shared on GitHub : <a href=https://github.com/Canop/miaou target=_blank>Canop/miaou</a>. If you'd like to help, contact me in the Miaou chat or in the StackOverflow JavaScript room where I often hang out. 
+				p Miaou has a small source code simply structured and should remain so. You may easily dive into the code which is shared on GitHub : <a href=https://github.com/Canop/miaou target=_blank>Canop/miaou</a>. If you'd like to help, contact me in the Miaou chat or in the Stack Overflow JavaScript room where I often hang out. 
 				h3 Plugins
 				p Miaou accepts server-side plugins. If you want to contribute a new feature, it probably should be done as a plugin, especially if it doesn't feel like a core feature.
 				h3 Bots


### PR DESCRIPTION
Added spaces in between to persist consistency with the Stack Overflow site itself, as well as other usages of SO across Miaou, which has spaces in between.