### PR TITLE
pull request fix image pasting from system clipboard on firefox

### DIFF
--- a/src/main-js/miaou.ed.upload.js
+++ b/src/main-js/miaou.ed.upload.js
@@ -36,16 +36,16 @@ miaou(function(ed){
 		ed.stateBeforePaste = {
 			selectionStart:input.selectionStart, selectionEnd:input.selectionEnd, value:input.value
 		};
-		var items = e.clipboardData.items || e.clipboardData.files;
-		for (var i=0; i<items.length; i++) {
-			var item = items[i];
-			if (/^image\//i.test(item.type)) {
-				if(item.getAsFile){
-					uploadFile(item.getAsFile());
-				}else{
-					//firefox compatibility (items are already typed as file)
-					uploadFile(item);
-				}
+		var files = e.clipboardData.files;
+		if (!files && e.clipboardData.items) {
+			files = e.clipboardData.items.map(function(item){
+				return item.getAsFile();
+			});
+		}
+		if (!files) return;
+		for (var i=0; i<files.length; i++) {
+			if (/^image\//i.test(files[i].type)) {
+				uploadFile(files[i]);
 				return false;
 			}
 		}

--- a/src/main-js/miaou.ed.upload.js
+++ b/src/main-js/miaou.ed.upload.js
@@ -40,7 +40,12 @@ miaou(function(ed){
 		for (var i=0; i<items.length; i++) {
 			var item = items[i];
 			if (/^image\//i.test(item.type)) {
-				uploadFile(item.getAsFile());
+				if(item.getAsFile){
+					uploadFile(item.getAsFile());
+				}else{
+					//firefox compatibility (items are already typed as file)
+					uploadFile(item);
+				}
 				return false;
 			}
 		}


### PR DESCRIPTION
Items are already typed as file on firefox's clipboard interface so the getAsFile method isn't avaiable. 