### PR TITLE
Xkcd boxing improvement

### DIFF
--- a/plugins/xkcd/css/xkcd-boxing.css
+++ b/plugins/xkcd/css/xkcd-boxing.css
@@ -1,3 +1,32 @@
 .xkcd {
-	text-align: center;
+    text-align: center;
+}
+
+.box .xkcd .abstract img {
+    max-height: none;
+    max-width: 100%;
+}
+
+.box .xkcd .abstract a.xkcd_link:hover, .box .xkcd .abstract a.xkcd_link:focus {
+    background-color: #FFF;
+    color: #6E7B91;
+    box-shadow: none;
+    -moz-box-shadow: none;
+    -webkit-box-shadow: none;
+}
+.box .xkcd .abstract a.xkcd_link {
+    background-color: #6E7B91;
+    color: #FFF;
+    border: 1.5px solid #333;
+    font-size: 16px;
+    font-weight: 600;
+    padding: 1.5px 12px;
+    margin: 0 4px;
+    text-decoration: none;
+    border-radius: 3px;
+    -moz-border-radius: 3px;
+    -webkit-border-radius: 3px;
+    box-shadow: 0 0 5px 0 grey;
+    -moz-box-shadow: 0 0 5px 0 gray;
+    -webkit-box-shadow: 0 0 5px 0 grey;
 }

--- a/plugins/xkcd/plugin.js
+++ b/plugins/xkcd/plugin.js
@@ -2,11 +2,11 @@
 // box xkcd links
 
 function abstract($, line){
-	var $xplain_base = 'http://www.explainxkcd.com/wiki/index.php/',
+	var xplain_base = 'http://www.explainxkcd.com/wiki/index.php/',
 		$box = $('<div/>').addClass('xkcd'),
 		$abstract = $('<div/>').addClass('abstract'),
 		$comic = $('#middleContainer'),
-		[$permaLink, $id] = $('#middleContainer').text().match(
+		[permaLink, id] = $('#middleContainer').text().match(
 			"Permanent link to this comic: (https://xkcd.com/([0-9]+))/"
 		).slice(1, 3);
 	if (!$comic.length) {
@@ -14,14 +14,14 @@ function abstract($, line){
 	}
 	$box.append($abstract);
 	$abstract.append($("<h1>").append(
-		$("<a>").attr("href", $permaLink).attr("target", "_blank").text(
+		$("<a>").attr("href", permaLink).attr("target", "_blank").text(
 			"XKCD: " + $("#ctitle").text()
 		)
 	));
 	$abstract.append($("<p>").append($('#comic img')));
 	$abstract.append(
 		$("<a>")
-			.attr("href", $xplain_base+$id )
+			.attr("href", xplain_base+id )
 			.attr("target", "_blank")
 			.text("Explain xkcd")
 			.attr("title", "It's 'cause you're dumb.")

--- a/plugins/xkcd/plugin.js
+++ b/plugins/xkcd/plugin.js
@@ -1,26 +1,40 @@
+
 // box xkcd links
 
 function abstract($, line){
-	var	$box = $('<div/>').addClass('xkcd'),
+	var $xplain_base = 'http://www.explainxkcd.com/wiki/index.php/',
+		$box = $('<div/>').addClass('xkcd'),
 		$abstract = $('<div/>').addClass('abstract'),
-		$comic = $('#middleContainer');
+		$comic = $('#middleContainer'),
+		[$permaLink, $id] = $('#middleContainer').text().match(
+			"Permanent link to this comic: (https://xkcd.com/([0-9]+))/"
+		).slice(1, 3);
 	if (!$comic.length) {
 		return null;
 	}
 	$box.append($abstract);
 	$abstract.append($("<h1>").append(
-		$("<a>").attr("href", line).attr("target", "_blank").text(
+		$("<a>").attr("href", $permaLink).attr("target", "_blank").text(
 			"XKCD: " + $("#ctitle").text()
 		)
 	));
 	$abstract.append($("<p>").append($('#comic img')));
+	$abstract.append(
+		$("<a>")
+			.attr("href", $xplain_base+$id )
+			.attr("target", "_blank")
+			.text("Explain xkcd")
+			.attr("title", "It's 'cause you're dumb.")
+			.addClass("xkcd_link")
+	);
+	
 	return $('<div>').append($box).html();
 }
 
 exports.init = function(miaou){
 	miaou.lib("page-boxers").register({
 		name: "xkcd",
-		pattern:/^\s*https?:\/\/(www\.)?xkcd\.com\/[0-9]*\/\s*$/,
+		pattern:/^\s*https?:\/\/(www\.)?xkcd\.com\/[0-9]*\/?\s*$/,
 		box:abstract
 	});
 }


### PR DESCRIPTION
trying to  improve xkcd boxing:
 - improved xkcd url detection: trailing / is now optional, allowing xkcd homepage to be detected correctly.
 - Added a Explain xkcd button under the comics linking to explain XKCD wiki
 - Added some css rules to make comics be as large and height as possible
 /!\ there is still one unresolved issue which may be linked to css modification:
   + the boxed xkcd is not folded\foldable when loading the page or when first published.
   + this seems not to affect chrome browser (but affect Firefox)
   + this issue seems to “disappear” as soon as the browser windows is resized

Here are screenshot of the issue, to show the difference I have included a wiki call which is correctly folded\foldable.
in Snobish-goldfish theme:
![foldboxbug-nowinmv-themesnobish](https://cloud.githubusercontent.com/assets/21103238/25785774/c0cfd6ee-3388-11e7-8505-d8a1c9aec952.png)
in slippery seal:
![foldboxbug-nowinmv-themeslipperyseal](https://cloud.githubusercontent.com/assets/21103238/25785776/cbfa094a-3388-11e7-9f35-ffec8d16f7e0.png)
in StingyRay:
![foldboxbug-nowinmv-themestingyray](https://cloud.githubusercontent.com/assets/21103238/25785778/db2295d6-3388-11e7-8578-996c27345b2b.png)

and same thing after the browser windows has been resized (same themes order):
![foldboxbug-winmv-themesnobishgoldfish](https://cloud.githubusercontent.com/assets/21103238/25785787/0abdb9b0-3389-11e7-8c90-e500355d828c.png)
![foldbug-winmv-themeslipperseal](https://cloud.githubusercontent.com/assets/21103238/25785788/0fe28bbe-3389-11e7-94e3-fdb243f18f31.png)
![foldboxbug-winmv-themstingyray](https://cloud.githubusercontent.com/assets/21103238/25785790/12f1c28e-3389-11e7-9e27-0eb66105e110.png)


if you have any idea on how I should fix it I'll do it right away

