### PR TITLE
AltGr & and Control conflict solving

### DIFF
--- a/src/main-js/miaou.ed.js
+++ b/src/main-js/miaou.ed.js
@@ -305,7 +305,7 @@ miaou(function(ed, chat, gui, locals, md, ms, notif, skin, usr, ws){
 		$input.on('keydown', function(e){
 			notif.userAct();
 			if (miaou.dialog.has()) return false;
-			if (e.ctrlKey && !e.shiftKey) {
+			if (e.ctrlKey && !e.shiftKey && !e.altkey) {
 				switch (e.which) {
 				case 75: // ctrl - K : toggle code
 					ed.code.onCtrlK.call(this);

--- a/src/page-js/chat.js
+++ b/src/page-js/chat.js
@@ -42,7 +42,7 @@ miaou(function(chat, locals){
 	});
 
 	$(window).on('keydown', function(e){
-		if (e.which===70 && e.ctrlKey) {
+		if (e.which===70 && e.ctrlKey && !e.altKey) {
 			tab("search");
 			return false;
 		}


### PR DESCRIPTION
This PR make sure for any Ctrl + <key> event that Miaou process that the "AltGraph" key
is not pressed.
This is because on windows when the AltGr key is pressed Windows is also sending a Ctrl event.
Thus we end up with some <key> event which have altKey and ctrlKey set to true.
In some keyboard configuration (bépo) it will conflict with Miaou shortcuts.