### PR TITLE
Solve AltGr confclicting Key on Windows

### DIFF
--- a/src/main-js/miaou.ed.js
+++ b/src/main-js/miaou.ed.js
@@ -277,7 +277,7 @@ miaou(function(ed, chat, gui, locals, md, ms, notif, skin, usr, ws){
 		$input.on('keydown', function(e){
 			notif.userAct();
 			if (miaou.dialog.has()) return false;
-			if (e.ctrlKey && !e.shiftKey) {
+			if (e.ctrlKey && !e.shiftKey && !e.altKey) {
 				switch (e.which) {
 				case 75: // ctrl - K : toggle code
 					ed.code.onCtrlK.call(this);
@@ -348,7 +348,7 @@ miaou(function(ed, chat, gui, locals, md, ms, notif, skin, usr, ws){
 		})
 		.on('keyup', function(e){
 			if (e.which===17) return; // ctrl-
-			if (e.which===86 && e.ctrlKey) return; // end of ctrl-V
+			if (e.which===86 && e.ctrlKey && !e.altKey) return; // end of ctrl-V
 			ed.stateBeforePaste = null;
 			ed.code.onMove();
 			if (e.which===9) return false; // tab

--- a/src/page-js/chat.js
+++ b/src/page-js/chat.js
@@ -42,7 +42,7 @@ miaou(function(chat, locals){
 	});
 
 	$(window).on('keydown', function(e){
-		if (e.which===70 && e.ctrlKey) {
+		if (e.which===70 && e.ctrlKey && !e.altKey) {
 			tab("search");
 			return false;
 		}

--- a/src/page-js/pad.js
+++ b/src/page-js/pad.js
@@ -127,7 +127,7 @@ miaou(function(chat, gui, locals, roomFinder, time, watch, ws){
 		if (e.which === 35 && !$('#rooms-panel').hasClass('open')) { // end
 			miaou.gui.scrollToBottom();
 		}
-		if ((e.ctrlKey && e.shiftKey && !e.altKey) && e.which===32) { // ctrl - space
+		if ((e.ctrlKey && !e.shiftKey && !e.altKey) && e.which===32) { // ctrl - space
 			toggleRoomsPanel();
 			return false;
 		}

--- a/src/page-js/pad.js
+++ b/src/page-js/pad.js
@@ -103,7 +103,7 @@ miaou(function(chat, gui, locals, roomFinder, time, watch, ws){
 	});
 
 	$(window).on('keydown', function(e){
-		if (e.which===70 && e.ctrlKey && !$('#rooms-panel').hasClass('open')) {
+		if (e.which===70 && e.ctrlKey && !e.altKey && !$('#rooms-panel').hasClass('open')) {
 			righttab("search");
 			return false;
 		}
@@ -127,7 +127,7 @@ miaou(function(chat, gui, locals, roomFinder, time, watch, ws){
 		if (e.which === 35 && !$('#rooms-panel').hasClass('open')) { // end
 			miaou.gui.scrollToBottom();
 		}
-		if ((e.ctrlKey && !e.shiftKey && !e.altKey) && e.which===32) { // ctrl - space
+		if ((e.ctrlKey && e.shiftKey && !e.altKey) && e.which===32) { // ctrl - space
 			toggleRoomsPanel();
 			return false;
 		}


### PR DESCRIPTION
This PR make sure for any Ctrl + event that Miaou process that the "AltGr(aph)" key is not pressed.
This is because on windows when the AltGr key is pressed Windows is also sending a Ctrl event.
Thus we end up with some keyboard event which have altKey and ctrlKey set to true, while in fact only the AltGr key is pressed.
In some keyboard configuration it will conflict with Miaou shortcuts.
Examples of conflict on a bépo keymap:
* AltGr+b should give a | (pipe) but Miaou interpret it as a Ctrl+b which mean «put in bold» an thus prevent the | to be printed in the chat.
* AltGr+i which is the dead key for ¨ (diaeresis) is for Miaou «put in italic», however this is less an issue because the ¨ is still printed at next character press; but it is still impairing.


Solution used: simply make sure that the keypress event has not Ctrl AND Alt has modifiers.
This solution was chosen for multiples reason:
1. When pressing on AltGr on Windows, it will always result in sending a Ctrl and an Alt Keypress event. however we could determine if AltGr was pressed by looking at the «location» of the Keypress
2. However when we are interested in a combination of key pressed we lose the location information.
3. It was quite simple and do not change a lot how Miaou work